### PR TITLE
Enable awakeFromNib to support instantiation via Xcode/IB.

### DIFF
--- a/SimpleGauge/Gauges/MSSimpleGauge.m
+++ b/SimpleGauge/Gauges/MSSimpleGauge.m
@@ -64,6 +64,11 @@
     [self setupArcLayers];
 }
 
+- (void)awakeFromNib
+{
+    [self setup];
+}
+
 - (id)initWithFrame:(CGRect)frame
 {
     self = [super initWithFrame:frame];


### PR DESCRIPTION
Tried to use gauges instantiated through Xcode and found -awakeFromNib was missing. Appears to work well once added.
